### PR TITLE
Add upgrade banner promoting improved version

### DIFF
--- a/index.html
+++ b/index.html
@@ -418,6 +418,22 @@
       cursor: not-allowed;
     }
 
+    .upgrade-banner {
+      max-width: 900px;
+      margin: 0 auto 18px;
+      padding: 10px 16px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-left: 4px solid var(--accent);
+      border-radius: var(--radius);
+      font-size: 0.95rem;
+    }
+
+    .upgrade-banner a {
+      font-weight: 600;
+      text-decoration: underline;
+    }
+
     .epub-progress {
       position: sticky;
       top: 0;
@@ -517,6 +533,8 @@
       <svg class="icon" onclick="toggleInfo();" viewBox="0 0 512 512" aria-hidden="true"><path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c9.4-9.4 24.6-9.4 33.9 0l47 47 47-47c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9l-47 47 47 47c9.4 9.4 9.4 24.6 0 33.9s-24.6 9.4-33.9 0l-47-47-47 47c-9.4 9.4-24.6 9.4-33.9 0s-9.4-24.6 0-33.9l47-47-47-47c-9.4-9.4-9.4-24.6 0-33.9z"/></svg>
     </header>
 
+    <p><strong>Try the improved version at <a href="https://bilingual-books.up.railway.app/" target="_blank" rel="noopener">bilingual-books.up.railway.app</a>.</strong></p>
+
     <p>This tool generates a side-by-side bilingual edition of any text you give it. Pick the input that matches what you have.</p>
 
     <h2>Paste text</h2>
@@ -537,6 +555,9 @@
     <script type="text/javascript" src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js" data-name="bmc-button" data-slug="lachydauth" data-color="#FFDD00" data-emoji=""  data-font="Cookie" data-text="Buy me a coffee" data-outline-color="#000000" data-font-color="#000000" data-coffee-color="#ffffff" ></script>
   </div>
   <div class="container del">
+    <div class="upgrade-banner">
+      An improved version is available at <a href="https://bilingual-books.up.railway.app/" target="_blank" rel="noopener">bilingual-books.up.railway.app</a> &mdash; faster, better translations, and more features.
+    </div>
     <header>
       <h1>Bilingual Book Generator</h1>
       <svg class="icon" id="info-button" onclick="toggleInfo()" viewBox="0 0 512 512" aria-hidden="true"><path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM169.8 165.3c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"/></svg>


### PR DESCRIPTION
## Summary
This PR adds promotional banners directing users to an improved version of the Bilingual Book Generator hosted at bilingual-books.up.railway.app.

## Key Changes
- **New CSS styling** for `.upgrade-banner` class with:
  - Centered layout with max-width of 900px
  - Accent-colored left border (4px) for visual emphasis
  - Styled links with bold font weight and underline
  - Consistent spacing and surface styling matching the app's design system

- **Two promotional banners added**:
  - Information section banner: Simple text link encouraging users to try the improved version
  - Main container banner: More detailed message highlighting key improvements (faster, better translations, more features)

- **Links configured** with `target="_blank"` and `rel="noopener"` for secure external navigation

## Implementation Details
The banners are strategically placed:
1. In the information panel (after the header close button)
2. At the top of the main content area (before the main header)

This dual placement ensures visibility whether users access the info section or scroll through the main content.

https://claude.ai/code/session_01LduVTn7hSUEpcR9tLFKMDb